### PR TITLE
Added support for docker to ease the process of deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.9
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 5000
+
+ENV FLASK_APP=application.py
+ENV FLASK_DEBUG=1
+ENV API_KEY=MY_API_KEY
+
+CMD ["python", "-m", "flask", "run"]

--- a/application.py
+++ b/application.py
@@ -7,7 +7,7 @@ app = Flask("__name__")
 
 
 # Set the API KEY of Javascript Maps API
-if not os.environ.get("API_KEY"):
+if not os.environ.get("API_KEY") or os.environ.get("API_KEY")=="MY_API_KEY":
     raise RuntimeError("API_KEY not set")
 
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  myapp:
+    image: python:3.9
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: sh -c "pip install --no-cache-dir -r requirements.txt && python -m flask run"
+    environment:
+      - FLASK_APP=application.py
+      - FLASK_DEBUG=1
+      - API_KEY=MY_API_KEY
+    ports:
+      - "5000:5000"


### PR DESCRIPTION
I created a Dockerfile and a docker-compose.yaml file to make it easier to deploy the webserver as a docker container.
To build a docker image from the Dockerfile, you can type `docker build -t fitfingers:latest .`, and then to run the image you can type `docker run -it fitfingers:latest`
Or you can run the image directly from the docker-compose file, by typing `docker-compose up`